### PR TITLE
Add require statement to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ $ npm i percom
 
   ## 1. Combinatioins (組み合わせ)
   ```JavaScript
+    const percom = require('percom');
+  
     percom.com(array,num); 
     //array => Target array (対象の配列)
     //num => Number to combine as combinations (組み合わせの数)


### PR DESCRIPTION
There are many ways to import/require npm modules when people use node or webpack or other bundlers.
I added the require statement to the docs to make it clear where the object `percom` comes from.